### PR TITLE
Make sudo optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ JupyterHub SlurmSpawner with a dynamic spawn form
 | --------------------------------- | :------ | :---------------------------------------------- | ------- |
 | `c.SlurmFormSpawner.disable_form`    | `CBool` | Disable the spawner input form, use only default values instead | `False` |
 | `c.SlurmFormSpawner.error_template_path` | `Unicode` | Path to the Jinja2 template of the error page | `os.path.join(sys.prefix, 'share',  'slurmformspawner', 'templates', 'error.html')` |
+| `c.SlurmFormSpawner.exec_prefix` | `Unicode` | Standard execution prefix for slurm commands | `sudo --preserve-env={keepvars} -u {username}` |
 | `c.SlurmFormSpawner.submit_template_path` | `Unicode` | Path to the Jinja2 template of the submit file | `os.path.join(sys.prefix, 'share', 'slurmformspawner', 'templates', 'submit.sh')` |
 | `c.SlurmFormSpawner.ui_args` | `Dict` | Dictionary of dictionaries describing the UI options | refer to `ui_args` section |
 

--- a/slurmformspawner/spawner.py
+++ b/slurmformspawner/spawner.py
@@ -46,10 +46,14 @@ class SlurmFormSpawner(SlurmSpawner):
         help="Path to the Jinja2 template of the form when there is a problem with Slurm"
     ).tag(config=True)
 
-    exec_prefix = ""
+    exec_prefix = Unicode(
+        "sudo --preserve-env={keepvars} -u {username}",
+        help="Standard execution prefix (e.g. sudo --preserve-env={keepvars} -u {username})"
+    ).tag(config=True)
+
     env_keep = []
-    batch_submit_cmd = "sudo --preserve-env={keepvars} -u {username} {slurm_bin_path}/sbatch --parsable"
-    batch_cancel_cmd = "sudo -u {username} {slurm_bin_path}/scancel {job_id}"
+    batch_submit_cmd = "{slurm_bin_path}/sbatch --parsable"
+    batch_cancel_cmd = "{slurm_bin_path}/scancel {job_id}"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
This is just a small change to allow job submission without root privileges by moving the sudo call to `exec_prefix`.

The default behaviour should not be affected, but `exec_prefix` can now be customised via the config.