### PR TITLE
allow accounts with whitespace to be used

### DIFF
--- a/share/templates/submit.sh
+++ b/share/templates/submit.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-{% if account %}#SBATCH --account={{account}}{% endif %}
+{% if account %}#SBATCH --account="{{account}}"{% endif %}
 #SBATCH --time={{runtime}}
 #SBATCH --output={{homedir}}/.jupyterhub_slurmspawner_%j.log
 #SBATCH --job-name=spawner-jupyterhub

--- a/slurmformspawner/slurm.py
+++ b/slurmformspawner/slurm.py
@@ -68,7 +68,7 @@ class SlurmAPI(SingletonConfigurable):
                                     'format=account', '-P', '--noheader'], encoding='utf-8')
         except CalledProcessError:
             return []
-        return string.split()
+        return string.splitlines()
 
     @cachedmethod(attrgetter('res_cache'))
     def get_reservations(self):


### PR DESCRIPTION
We have a few slurm accounts that have whitespace in their name and the current implementation does not take handle it correctly.

