### PR TITLE
handle missing form elements

### DIFF
--- a/share/templates/form.html
+++ b/share/templates/form.html
@@ -14,13 +14,15 @@ function onChange() {
 }
 function set_profile_params(profile) {
   for (const [key, value] of Object.entries(profile_map[profile]['params'])) {
-    if (value !== null) {
+    const element = document.getElementById(key); // Get the element once
+    if (element) { // Check if the element exists
       if (typeof value == "boolean") {
-        document.getElementById(key).checked = value;
+        element.checked = value;
+      } else {
+        element.value = value;
       }
-      else {
-        document.getElementById(key).value = value;
-      }
+    } else {
+      console.warn(`Element with ID '${key}' not found. Skipping property assignment.`); // Log a warning instead of erroring
     }
   }
 }


### PR DESCRIPTION
When some form elements are not displayed, for example if "features" are not defined, they are still defined in the profiles. The Javascript code attempts to set those elements, but it generates an error. 

I analyzed this with Chrome's AI insights, which revealed: 
<img width="1231" height="1198" alt="Capture d’écran, le 2026-02-18 à 16 10 37" src="https://github.com/user-attachments/assets/1ec8772f-5648-44e5-baff-7bb6493896af" />

and suggested the code included in this patch
<img width="1171" height="491" alt="Capture d’écran, le 2026-02-18 à 16 10 53" src="https://github.com/user-attachments/assets/873ad6d8-cc08-4386-83a2-28485839041d" />
