### PR TITLE
Fix multivalued features

### DIFF
--- a/share/templates/form.html
+++ b/share/templates/form.html
@@ -14,15 +14,33 @@ function onChange() {
 }
 function set_profile_params(profile) {
   for (const [key, value] of Object.entries(profile_map[profile]['params'])) {
-    const element = document.getElementById(key); // Get the element once
-    if (element) { // Check if the element exists
-      if (typeof value == "boolean") {
-        element.checked = value;
-      } else {
-        element.value = value;
+    if (value.constructor === Array) {
+      for (const elem of value) {
+        // first, set all elements to false
+        const all_elements = document.getElementsByName(key);
+        for (const element of all_elements) {
+          element.checked = false;
+        }
+        // then set only the ones listed to true
+        const element = document.getElementById(key + "-" + elem);
+        if (element) { // Check if the element exists
+          element.checked = true;
+        } else {
+          console.warn(`Element with ID '${key}-${elem}' not found. Skipping property assignment.`); // Log a warning instead of erroring
+        }
       }
-    } else {
-      console.warn(`Element with ID '${key}' not found. Skipping property assignment.`); // Log a warning instead of erroring
+    }
+    else {
+      const element = document.getElementById(key); // Get the element once
+      if (element) { // Check if the element exists
+        if (typeof value == "boolean") {
+          element.checked = value;
+        } else {
+          element.value = value;
+        }
+      } else {
+        console.warn(`Element with ID '${key}' not found. Skipping property assignment.`); // Log a warning instead of erroring
+      }
     }
   }
 }

--- a/slurmformspawner/form.py
+++ b/slurmformspawner/form.py
@@ -186,10 +186,10 @@ class SbatchForm(Configurable):
             dict_ = getattr(self, key)
             if dict_.get('lock') is True and dict_.get('def') is None:
                 raise Exception(f'You need to define a default value for {key} because it is locked.')
-            if key in user_options:
-                self.form[key].process(formdata=FakeMultiDict({key : [user_options[key]]}))
-            else:
-                self.form[key].process(formdata=FakeMultiDict({key : [self.resolve(getattr(self, key).get('def'))]}))
+            value = user_options[key] if key in user_options else self.resolve(getattr(self, key).get('def'))
+            if not isinstance(self.form[key], SelectMultipleField):
+                value = [value]
+            self.form[key].process(formdata=FakeMultiDict({key : value }))
 
     @property
     def data(self):


### PR DESCRIPTION
This PR fixes two bugs with multi-valued select options (checkboxes)

1. When defining the values of the form, arrays were getting converted to strings (i.e. `feature: []` became `feature: '[]'` and `feature: ['f1', 'f2']` became `feature: "['f1', 'f2']"` 
2. When processing profile data to configure the form on the client side, multi-valued options were not handled correctly. Switching profile was not selecting the checkboxes according to the definition of the profile. 

